### PR TITLE
minimize round-off error

### DIFF
--- a/src/com/buzzingandroid/ui/ViewAspectRatioMeasurer.java
+++ b/src/com/buzzingandroid/ui/ViewAspectRatioMeasurer.java
@@ -81,15 +81,15 @@ public class ViewAspectRatioMeasurer {
 			/*
 			 * Possibility 2: Width dynamic, height fixed
 			 */
-			measuredWidth = (int) Math.min( widthSize, heightSize * aspectRatio );
-			measuredHeight = (int) (measuredWidth / aspectRatio);
+			measuredHeight = (int) Math.min( heightSize, widthSize / aspectRatio );
+			measuredWidth = (int) (measuredHeight * aspectRatio);
 			
 		} else if ( widthMode == MeasureSpec.EXACTLY ) {
 			/*
 			 * Possibility 3: Width fixed, height dynamic
 			 */
-			measuredHeight = (int) Math.min( heightSize, widthSize / aspectRatio );
-			measuredWidth = (int) (measuredHeight * aspectRatio);
+			measuredWidth = (int) Math.min( widthSize, heightSize * aspectRatio );
+			measuredHeight = (int) (measuredWidth / aspectRatio);
 			
 		} else {
 			/* 


### PR DESCRIPTION
when using fixed width the measuredWidth value should be more exactly, so it should be calculated first. happens e.g. when using DIN page norm 0.709219858
